### PR TITLE
Refactor apps to be fully event-driven in their button handling

### DIFF
--- a/drivers/tidal_helpers/tidal_helpers.c
+++ b/drivers/tidal_helpers/tidal_helpers.c
@@ -95,8 +95,12 @@ STATIC void tidal_lightsleep_isr(void *arg) {
     // In the interests of consistency, also stop the GPIO from triggering wakeup
     gpio_wakeup_disable(gpio);
 
-    // Following is as per machine_pin_isr_handler
+    // Following is based on machine_pin_isr_handler
     mp_obj_t handler = MP_STATE_PORT(machine_pin_irq_handler)[gpio];
+    if (handler == mp_const_none || handler == MP_OBJ_NULL) {
+        // It shouldn't be possible to get to here with handler not valid, but...
+        return;
+    }
     mp_sched_schedule(handler, MP_OBJ_NEW_SMALL_INT(gpio));
     mp_hal_wake_main_task_from_isr();
 }

--- a/drivers/tidal_helpers/tidal_helpers.c
+++ b/drivers/tidal_helpers/tidal_helpers.c
@@ -2,22 +2,39 @@
 #include "esp_log.h"
 #include "sdkconfig.h"
 #include "mphalport.h"
+#include "modmachine.h" // for machine_pin_type
 #include "esp_sleep.h"
+#include "rom/uart.h"
 
+// Have to redefine this from machine_pin.c, unfortunately
+typedef struct _machine_pin_obj_t {
+    mp_obj_base_t base;
+    gpio_num_t id;
+} machine_pin_obj_t;
+
+STATIC gpio_num_t get_pin(mp_obj_t pin_obj) {
+    if (mp_obj_is_int(pin_obj)) {
+        return (gpio_num_t)mp_obj_get_int(pin_obj);
+    } else if (mp_obj_get_type(pin_obj) != &machine_pin_type) {
+        mp_raise_ValueError(MP_ERROR_TEXT("expecting a pin or integer pin number"));
+    }
+    machine_pin_obj_t *self = pin_obj;
+    return self->id;
+}
 
 STATIC mp_obj_t tidal_helper_get_variant() {
     mp_obj_t devboard = MP_ROM_QSTR(MP_QSTR_devboard);
     mp_obj_t proto = MP_ROM_QSTR(MP_QSTR_prototype);
     mp_obj_t prod = MP_ROM_QSTR(MP_QSTR_production);
-    
-    #ifdef CONFIG_TIDAL_VARIANT_DEVBOARD
+    #if defined(CONFIG_TIDAL_VARIANT_DEVBOARD)
+        (void)proto; (void)prod;
         return devboard;
+    #elif defined(CONFIG_TIDAL_VARIANT_PROTOTYPE)
+        (void)devboard; (void)prod;
+        return proto;
     #else
-        #ifdef CONFIG_TIDAL_VARIANT_PROTOTYPE
-            return proto;
-        #else
-            return prod;
-        #endif
+        (void)devboard; (void)proto;
+        return prod;
     #endif
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(tidal_helper_get_variant_obj, tidal_helper_get_variant);
@@ -38,7 +55,7 @@ STATIC mp_obj_t tidal_esp_sleep_pd_config(mp_obj_t domain_obj, mp_obj_t option_o
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(tidal_esp_sleep_pd_config_obj, tidal_esp_sleep_pd_config);
 
 STATIC mp_obj_t tidal_gpio_wakeup(mp_obj_t gpio_obj, mp_obj_t level_obj) {
-    gpio_num_t gpio = (gpio_num_t)mp_obj_get_int(gpio_obj);
+    gpio_num_t gpio = get_pin(gpio_obj);
     gpio_int_type_t level = (gpio_int_type_t)mp_obj_get_int(level_obj);
     esp_err_t err;
     if (level) {
@@ -52,8 +69,8 @@ STATIC mp_obj_t tidal_gpio_wakeup(mp_obj_t gpio_obj, mp_obj_t level_obj) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(tidal_gpio_wakeup_obj, tidal_gpio_wakeup);
 
 STATIC mp_obj_t tidal_gpio_hold(mp_obj_t gpio_obj, mp_obj_t flag_obj) {
-    gpio_num_t gpio = (gpio_num_t)mp_obj_get_int(gpio_obj);
-    int flag = (gpio_int_type_t)mp_obj_is_true(flag_obj);
+    gpio_num_t gpio = get_pin(gpio_obj);
+    bool flag = mp_obj_is_true(flag_obj);
     esp_err_t err;
     if (flag) {
         err = gpio_hold_en(gpio);
@@ -65,8 +82,73 @@ STATIC mp_obj_t tidal_gpio_hold(mp_obj_t gpio_obj, mp_obj_t flag_obj) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(tidal_gpio_hold_obj, tidal_gpio_hold);
 
+STATIC void tidal_lightsleep_isr(void *arg) {
+    gpio_num_t gpio = (gpio_num_t)arg;
+    // Lightsleep GPIO interrupts are always level triggered, meaning we need to
+    // immediately disable it to prevent it firing continuously (which will
+    // almost immediately cause the IRQ watchdog to expire and reset the board).
+    // It is the responsibility of the handler to re-enable or reconfigure it as
+    // needed. Note that this alone doesn't prevent the GPIO level from
+    // triggering wake from lightsleep, it just won't call this ISR.
+    gpio_intr_disable(gpio);
+
+    // In the interests of consistency, also stop the GPIO from triggering wakeup
+    gpio_wakeup_disable(gpio);
+
+    // Following is as per machine_pin_isr_handler
+    mp_obj_t handler = MP_STATE_PORT(machine_pin_irq_handler)[gpio];
+    mp_sched_schedule(handler, MP_OBJ_NEW_SMALL_INT(gpio));
+    mp_hal_wake_main_task_from_isr();
+}
+
+// tidal_helpers.set_lightsleep_irq(Pin|int, level, handler) or
+// tidal_helpers.set_lightsleep_irq(Pin|int, None, None) to disable
+STATIC mp_obj_t tidal_set_lightsleep_irq(mp_obj_t gpio_obj, mp_obj_t level_obj, mp_obj_t handler) {
+    gpio_num_t gpio = get_pin(gpio_obj);
+
+    // This disables the interrupt as the first thing it does
+    esp_err_t err = gpio_isr_handler_remove(gpio);
+    check_esp_err(err);
+
+    if (handler == mp_const_none) {
+        gpio_wakeup_disable(gpio);
+        // Return with interrupt disabled and no ISR or wake enabled
+        return mp_const_none;
+    }
+
+    // Stash handler in machine state, as a convenient place to put it
+    MP_STATE_PORT(machine_pin_irq_handler)[gpio] = handler;
+
+    int level = mp_obj_get_int(level_obj);
+    // Configure wake params - note this includes (the equivalent to) a call to
+    // gpio_set_intr_type. Interrupt remains disabled.
+    err = gpio_wakeup_enable(gpio, level ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL);
+    check_esp_err(err);
+
+    // Finally, install ISR handler and enable interrupt.
+    err = gpio_isr_handler_add(gpio, tidal_lightsleep_isr, (void *)gpio);
+    check_esp_err(err);
+
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_3(tidal_set_lightsleep_irq_obj, tidal_set_lightsleep_irq);
+
+STATIC mp_obj_t tidal_gpio_intr_enable(mp_obj_t gpio_obj, mp_obj_t flag_obj) {
+    gpio_num_t gpio = get_pin(gpio_obj);
+    bool flag = mp_obj_is_true(flag_obj);
+    esp_err_t err;
+    if (flag) {
+        err = gpio_intr_enable(gpio);
+    } else {
+        err = gpio_intr_disable(gpio);
+    }
+    check_esp_err(err);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(tidal_gpio_intr_enable_obj, tidal_gpio_intr_enable);
+
 STATIC mp_obj_t tidal_gpio_sleep_sel(mp_obj_t gpio_obj, mp_obj_t flag_obj) {
-    gpio_num_t gpio = (gpio_num_t)mp_obj_get_int(gpio_obj);
+    gpio_num_t gpio = get_pin(gpio_obj);
     bool flag = mp_obj_is_true(flag_obj);
     esp_err_t err;
     if (flag) {
@@ -86,6 +168,29 @@ STATIC mp_obj_t tidal_esp_sleep_enable_gpio_switch(mp_obj_t flag_obj) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(tidal_esp_sleep_enable_gpio_switch_obj, tidal_esp_sleep_enable_gpio_switch);
 
+STATIC mp_obj_t tidal_uart_tx_flush(mp_obj_t id_obj) {
+    int id = mp_obj_get_int(id_obj);
+    uart_tx_flush(id);
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(tidal_uart_tx_flush_obj, tidal_uart_tx_flush);
+
+STATIC mp_obj_t tidal_lightsleep(mp_obj_t time_obj) {
+    int time_ms = mp_obj_get_int(time_obj);
+    if (time_ms) {
+        esp_sleep_enable_timer_wakeup(((uint64_t)time_ms) * 1000);
+    }
+
+    esp_light_sleep_start();
+
+    if (time_ms) {
+        // Reset this
+        esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_TIMER);
+    }
+
+    return MP_OBJ_NEW_SMALL_INT(esp_sleep_get_wakeup_cause());
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(tidal_lightsleep_obj, tidal_lightsleep);
 
 STATIC const mp_rom_map_elem_t tidal_helpers_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ota) },
@@ -93,9 +198,13 @@ STATIC const mp_rom_map_elem_t tidal_helpers_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_esp_sleep_enable_gpio_wakeup), MP_ROM_PTR(&tidal_esp_sleep_enable_gpio_wakeup_obj) },
     { MP_ROM_QSTR(MP_QSTR_esp_sleep_pd_config), MP_ROM_PTR(&tidal_esp_sleep_pd_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_gpio_wakeup), MP_ROM_PTR(&tidal_gpio_wakeup_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_lightsleep_irq), MP_ROM_PTR(&tidal_set_lightsleep_irq_obj) },
     { MP_ROM_QSTR(MP_QSTR_gpio_hold), MP_ROM_PTR(&tidal_gpio_hold_obj) },
+    { MP_ROM_QSTR(MP_QSTR_gpio_intr_enable), MP_ROM_PTR(&tidal_gpio_intr_enable_obj) },
     { MP_ROM_QSTR(MP_QSTR_gpio_sleep_sel), MP_ROM_PTR(&tidal_gpio_sleep_sel_obj) },
     { MP_ROM_QSTR(MP_QSTR_esp_sleep_enable_gpio_switch), MP_ROM_PTR(&tidal_esp_sleep_enable_gpio_switch_obj) },
+    { MP_ROM_QSTR(MP_QSTR_uart_tx_flush), MP_ROM_PTR(&tidal_uart_tx_flush_obj) },
+    { MP_ROM_QSTR(MP_QSTR_lightsleep), MP_ROM_PTR(&tidal_lightsleep_obj) },
 
     { MP_ROM_QSTR(MP_QSTR_ESP_PD_DOMAIN_RTC_PERIPH), MP_ROM_INT(ESP_PD_DOMAIN_RTC_PERIPH) },
     { MP_ROM_QSTR(MP_QSTR_ESP_PD_OPTION_OFF), MP_ROM_INT(ESP_PD_OPTION_OFF) },

--- a/modules/app.py
+++ b/modules/app.py
@@ -1,92 +1,71 @@
-import time
-import uasyncio
-
-class MainTask:
-    
-    _awaitables = {}
-    _current_app = None
-    
-    async def sleep(self):
-        # Sleep for 5 minutes, wrapped in an async funtion
-        # so it can be scheduled as a cancellable task
-        await uasyncio.sleep(300)
-    
-    async def app_active(self, app: str) -> bool:
-        """Await this to pause execution until the specified app
-        is active. Returns a boolean which is True if the app was active
-        or False if we waited for it to become active. """
-        # Infinite loop while the app is inactive, but with
-        # a sleep in the middle so it doesn't use resources.
-        was_already_active = self._current_app == app
-        while self._current_app != app:
-            task = self._awaitables.get(
-                app,
-                uasyncio.create_task(self.sleep())
-            )
-            self._awaitables[app] = task
-            try:
-                await task
-            except:
-                # We have context switched, swallow that CancelledError
-                pass
-            # Remove the awaitable, so it's re-created next time it's
-            # requested
-            del self._awaitables[app]
-        return was_already_active
-    
-    def context_changed(self, app: str) -> None:
-        # Cancel the corresponding sleep for this app, to wake it
-        self._current_app = app
-        print(f"Changing context to {app}")
-        if awaitable := self._awaitables.get(app):
-            awaitable.cancel()
-        return
-
-
-task_coordinator = MainTask()
-
+import tidal
+from buttons import Buttons
+from scheduler import get_scheduler
+import textwindow
 
 class App:
     app_id = __name__
-    interval = 0.1
-    post_wake_interval = 0.5
-    running = True
+
+    # Defaults for TextApp and MenuApp
+    BG = tidal.BLUE
+    FG = tidal.WHITE
+
+    def __init__(self):
+        self.started = False
+        self.buttons = Buttons()
 
     def run_sync(self):
-        self.on_start()
-        self.on_wake()
-        time.sleep(self.post_wake_interval)
-        while self.running:
-            self.update()
-            time.sleep(self.interval)
-        self.on_stop()
-
-    async def run(self):
-        self.on_start()
-        first_run = True
-        while self.running:
-            was_active = await task_coordinator.app_active(self.app_id)
-            if first_run or not was_active:
-                self.on_wake()
-                first_run = False
-                await uasyncio.sleep(self.post_wake_interval)
-            self.update()
-            await uasyncio.sleep(self.interval)
-        self.on_stop()
-    
-    async def isActive(self):
-        while True:
-            yield
+        get_scheduler().main(self)
 
     def on_start(self):
-        return NotImplemented
+        if self.buttons:
+            self.buttons.on_press(tidal.BUTTON_FRONT, lambda _: self.navigate_back())
 
     def on_stop(self):
         return NotImplemented
 
-    def on_wake(self):
-        return NotImplemented
-    
-    def update(self):
+    def on_activate(self):
         return NotImplemented
 
+    def on_deactivate(self):
+        return NotImplemented
+
+    def check_for_interrupts(self):
+        if self.buttons:
+            return self.buttons.check_for_interrupts()
+        return False
+
+    def navigate_back(self):
+        get_scheduler().switch_app(None)
+
+    def after(self, ms, callback):
+        return get_scheduler().after(ms, callback)
+
+    def periodic(self, ms, callback):
+        return get_scheduler().periodic(ms, callback)
+
+class TextApp(App):
+    def __init__(self):
+        super().__init__()
+        self.window = textwindow.TextWindow(self.BG, self.FG, self.title)
+
+
+class MenuApp(App):
+    def __init__(self):
+        super().__init__()
+        self.window = textwindow.Menu(self.BG, self.FG, self.FOCUS_BG, self.FOCUS_FG, self.title, self.choices)
+
+    def on_start(self):
+        super().on_start()
+        win = self.window
+        self.buttons.on_press(tidal.JOY_DOWN, lambda _: win.set_focus_idx(win.focus_idx() + 1))
+        self.buttons.on_press(tidal.JOY_UP, lambda _: win.set_focus_idx(win.focus_idx() - 1))
+        def select(_):
+            self.choices[win.focus_idx()][1]()
+        self.buttons.on_press(tidal.JOY_CENTRE, select, autorepeat=False)
+        self.buttons.on_press(tidal.BUTTON_A, select, autorepeat=False)
+        self.buttons.on_press(tidal.BUTTON_B, select, autorepeat=False)
+
+    def on_activate(self):
+        super().on_activate()
+        self.window.cls()

--- a/modules/app.py
+++ b/modules/app.py
@@ -4,7 +4,6 @@ from scheduler import get_scheduler
 import textwindow
 
 class App:
-    app_id = __name__
 
     # Defaults for TextApp and MenuApp
     BG = tidal.BLUE
@@ -13,6 +12,12 @@ class App:
     def __init__(self):
         self.started = False
         self.buttons = Buttons()
+
+    def get_app_id(self):
+        if name := getattr(self, "app_id", None):
+            return name
+        else:
+            return self.__class__.__name__
 
     def run_sync(self):
         get_scheduler().main(self)
@@ -44,6 +49,7 @@ class App:
     def periodic(self, ms, callback):
         return get_scheduler().periodic(ms, callback)
 
+
 class TextApp(App):
     def __init__(self):
         super().__init__()
@@ -53,15 +59,16 @@ class TextApp(App):
 class MenuApp(App):
     def __init__(self):
         super().__init__()
-        self.window = textwindow.Menu(self.BG, self.FG, self.FOCUS_BG, self.FOCUS_FG, self.title, self.choices)
 
     def on_start(self):
         super().on_start()
+        self.window = textwindow.Menu(self.BG, self.FG, self.FOCUS_BG, self.FOCUS_FG, self.title, self.choices)
         win = self.window
         self.buttons.on_press(tidal.JOY_DOWN, lambda _: win.set_focus_idx(win.focus_idx() + 1))
         self.buttons.on_press(tidal.JOY_UP, lambda _: win.set_focus_idx(win.focus_idx() - 1))
         def select(_):
-            self.choices[win.focus_idx()][1]()
+            if len(win.choices):
+                win.choices[win.focus_idx()][1]()
         self.buttons.on_press(tidal.JOY_CENTRE, select, autorepeat=False)
         self.buttons.on_press(tidal.BUTTON_A, select, autorepeat=False)
         self.buttons.on_press(tidal.BUTTON_B, select, autorepeat=False)

--- a/modules/app_launcher/__init__.py
+++ b/modules/app_launcher/__init__.py
@@ -18,11 +18,11 @@ class Launcher(MenuApp):
     def choices(self):
         # Note, the text for each choice needs to be <= 16 characters in order to fit on screen
         return (
-            ({"text": "USB Keyboard"}, lambda: self.launch("hid", "USBKeyboard")),
-            ({"text": "Web REPL"}, lambda: self.launch("web_repl", "WebRepl")),
-            ({"text": "Torch"}, lambda: self.launch("torch", "Torch")),
-            ({"text": "Logo"}, lambda: self.launch("emflogo", "EMFLogo")),
-            ({"text": "Update Firmware"}, lambda: self.launch("otaupdate", "OtaUpdate")),
+            ("USB Keyboard", lambda: self.launch("hid", "USBKeyboard")),
+            ("Web REPL", lambda: self.launch("web_repl", "WebRepl")),
+            ("Torch", lambda: self.launch("torch", "Torch")),
+            ("Logo", lambda: self.launch("emflogo", "EMFLogo")),
+            ("Update Firmware", lambda: self.launch("otaupdate", "OtaUpdate")),
         )
     
     # Boot entry point
@@ -33,6 +33,18 @@ class Launcher(MenuApp):
         super().__init__()
         self._apps = {}
         self.show_splash = True
+        if not get_scheduler().is_sleep_enabled():
+            self.title += "\nSLEEP DISABLED"
+
+    def on_start(self):
+        super().on_start()
+        initial_item = 0
+        try:
+            with open("lastapplaunch.txt") as f:
+                initial_item = int(f.read())
+        except:
+            pass
+        self.window.set_focus_idx(initial_item, redraw=False)
 
     def on_activate(self):
         if self.show_splash and SPLASHSCREEN_TIME:
@@ -55,4 +67,6 @@ class Launcher(MenuApp):
             module = __import__(module_name)
             app = getattr(module, app_name)()
             self._apps[app_name] = app
+        with open("lastapplaunch.txt", "w") as f:
+            f.write(str(self.window.focus_idx()))
         get_scheduler().switch_app(app)

--- a/modules/boot.py
+++ b/modules/boot.py
@@ -1,4 +1,5 @@
 import tidal
+import tidal_helpers
 from esp32 import Partition
 
 # sleep_sel just gets in the way of using lightsleep

--- a/modules/boot.py
+++ b/modules/boot.py
@@ -1,8 +1,4 @@
-import emf_png
 import tidal
-import app
-import time
-import tidal_helpers
 from esp32 import Partition
 
 # sleep_sel just gets in the way of using lightsleep
@@ -12,34 +8,15 @@ tidal_helpers.esp_sleep_enable_gpio_switch(False)
 tidal.usb.initialize()
 tidal.init_lcd()
 
-tidal.display.bitmap(emf_png, 0, 0)
-time.sleep(0.5)
-
-if tidal.JOY_DOWN.value() == 0:
-    # This is an emergency boot
+if tidal.BUTTON_FRONT.value() == 0:
+    # Boot to the recovery menu
     from bootmenu import BootMenu
-
     menu = BootMenu()
-    Partition.mark_app_valid_cancel_rollback()
-    menu.run_sync()
 else:
     from app_launcher import Launcher
-    import uasyncio
-
     menu = Launcher()
-    
-    # If we've made it to here, any OTA update has _probably_ gone ok...
-    Partition.mark_app_valid_cancel_rollback()
 
-    async def main():
-        menu_task = uasyncio.create_task(menu.run())
-        app.task_coordinator.context_changed("menu")
-        await menu_task
-    uasyncio.run(main())
+# If we've made it to here, any OTA update has _probably_ gone ok...
+Partition.mark_app_valid_cancel_rollback()
 
-    
-
-# TODO: figure out how to get show_boot_menu to use callbacks and become async
-# so it needn't be wrapped in a thread to prevent it blocking the serial/USB
-# REPL.
-menu = BootMenu()
+menu.main()

--- a/modules/bootmenu.py
+++ b/modules/bootmenu.py
@@ -1,17 +1,10 @@
-import st7789
-import tidal
-from textwindow import Menu
-from app import App
+from tidal import *
+import textwindow
+import time
 
-
-def web_repl():
-    import web_repl
-    app = web_repl.WebRepl()
-    app.run_sync()
-
-def hid():
-    import hid
-    app = hid.USBKeyboard()
+def run_applauncher():
+    import app_launcher
+    app = app_launcher.Launcher()
     app.run_sync()
 
 def torch():
@@ -24,38 +17,68 @@ def run_otaupdate():
     app = otaupdate.OtaUpdate()
     app.run_sync()
 
+def erase_storage():
+    from esp32 import Partition
+    MP_BLOCKDEV_IOCTL_BLOCK_ERASE = 6
 
-class BootMenu(Menu, App):
+    window = textwindow.TextWindow(RED, WHITE, "Erase storage")
+    window.cls()
+    window.println("Press [A] to")
+    window.println("erase VFS")
+    window.println("partition.")
+    window.println()
+    window.println("BE VERY SURE")
+    window.println("ABOUT THIS!")
+    while True:
+        if BUTTON_A.value() == 0:
+            break
+        time.sleep(0.2)
+    window.println()
 
-    app_id = "menu"
-    title = "Emergency Menu"
+    partitions = Partition.find(type=Partition.TYPE_DATA, subtype=0x81)
+    if len(partitions) != 1:
+        window.println("VFS Partition")
+        window.println("not found!")
+        return
 
-    BG = st7789.RED
-    FG = st7789.WHITE
-    FOCUS_FG = st7789.RED
-    FOCUS_BG = st7789.WHITE
+    vfs_partition = partitions[0]
+    num_blocks = vfs_partition.info()[3] // 4096
+    percent = -1
+    for i in range(0, num_blocks):
+        new_percent = (i * 100) // num_blocks
+        if new_percent > percent:
+            percent = new_percent
+            window.println("Erasing... {}%".format(percent), window.get_next_line())
+        vfs_partition.ioctl(MP_BLOCKDEV_IOCTL_BLOCK_ERASE, i)
+    window.println("Erase complete")
+
+# Note, this is a minimal app definition that does not rely on IRQs, timers or uasyncio working
+class BootMenu:
+
+    title = "Recovery Menu"
+    BG = RED
+    FG = WHITE
+    FOCUS_FG = RED
+    FOCUS_BG = WHITE
 
     # Note, the text for each choice needs to be <= 16 characters in order to fit on screen
     choices = (
-        ({"text": "USB Keyboard"}, hid),
-        ({"text": "Web REPL"}, web_repl),
-        ({"text": "Torch"}, torch),
+        ({"text": "App Launcher"}, run_applauncher),
         ({"text": "Firmware Update"}, run_otaupdate),
+        ({"text": "Erase storage"},  erase_storage),
+        ({"text": "Torch"}, torch),
     )
 
-    def on_wake(self):
-        self.cls()
-
-    def update(self):
-        if tidal.JOY_DOWN.value() == 0:
-            self.focus_idx += 1
-        elif tidal.JOY_UP.value() == 0:
-            self.focus_idx -= 1
-        elif any((
-                tidal.BUTTON_A.value() == 0,
-                tidal.BUTTON_B.value() == 0,
-                tidal.JOY_CENTRE.value() == 0,
-            )):
-            with open("lastbootitem.txt", "wt", encoding="ascii") as f:
-                f.write(str(self.focus_idx))
-            self.choices[self.focus_idx][1]()
+    def main(self):
+        print("Showing Recovery Menu")
+        window = textwindow.Menu(self.BG, self.FG, self.FOCUS_BG, self.FOCUS_FG, self.title, self.choices)
+        window.cls()
+        while True:
+            if JOY_DOWN.value() == 0:
+                window.set_focus_idx(window.focus_idx() + 1)
+            elif JOY_UP.value() == 0:
+                window.set_focus_idx(window.focus_idx() - 1)
+            elif JOY_CENTRE.value() == 0:
+                self.choices[window.focus_idx()][1]()
+                break
+            time.sleep(0.2)

--- a/modules/buttons.py
+++ b/modules/buttons.py
@@ -110,7 +110,7 @@ class Buttons:
         if not self.is_active():
             return
 
-        print(f"Deactivating {self}")
+        # print(f"Deactivating {self}")
         if self._autorepeat_timer:
             self._autorepeat_timer.cancel()
             self._autorepeat_timer = None
@@ -132,7 +132,7 @@ class Buttons:
             _current.deactivate()
         _current = self
 
-        print(f"Activating {self}")
+        # print(f"Activating {self}")
         for button in self._callbacks.values():
             self._register_irq(button)
 

--- a/modules/buttons.py
+++ b/modules/buttons.py
@@ -1,31 +1,166 @@
-import time
+import tidal
+import tidal_helpers
+from machine import Timer
+import uasyncio
+
+# Only one Buttons object can be active at a time - whichever most recently
+# called activate() gets the interrupts.
+_current = None
+
+def _button_irq(pin):
+    if _current:
+        _current._isr_flag = True
+
+class Button:
+    def __init__(self, pin, callback, updown, autorepeat):
+        self.pin = pin
+        self.callback = callback
+        self.updown = updown
+        self.autorepeat = autorepeat
+        self.state = pin.value()
+
+    def should_autorepeat(self):
+        return (not self.updown) and self.autorepeat and (self.state == 0)
+
 
 class Buttons:
+
+    autorepeat_delay_time = 200 # ms
+    autorepeat_time = 200 # ms
+
     def __init__(self):
-        # stack of arrays of callbacks (so you can push/pop entire collections of callbacks)
-        self._press_callbacks = [[]]
+        self._callbacks = {} # str(pin) -> Button
+        self._timer = Timer(tidal.TIMER_ID_BUTTONS)
+        self._autorepeating_button = None
+        self._isr_flag = False
 
-    def on_press(self, pin, callback):
-        current = self._press_callbacks[-1]
-        for (i, (existing_pin, _)) in enumerate(current):
-            if existing_pin == pin:
-                del current[i]
-                break
-        current.append((pin, callback))
+    def is_active(self):
+        return _current == self
 
-    def push(self):
-        self._press_callbacks.append([])
+    def on_press(self, pin, callback, autorepeat=True):
+        if autorepeat is True:
+            autorepeat = self.autorepeat_time
+        self._register_button(Button(pin, callback, False, autorepeat))
 
-    def pop(self):
-        del _self.press_callbacks[-1]
-        if len(self._press_callbacks) == 0:
-            self.push()
+    def on_up_down(self, pin, callback):
+        self._register_button(Button(pin, callback, True, False))
+
+    def _register_button(self, button):
+        k = str(button.pin) # Pin really needs to be hashable...
+        if button.callback:
+            self._callbacks[k] = button
+            if self.is_active():
+                self._register_irq(button)
+        elif self._is_registered(button):
+            del self._callbacks[k]
+            if self.is_active():
+                tidal_helpers.set_lightsleep_irq(button.pin, None, None)
+
+    def _is_registered(self, button):
+        return str(button.pin) in self._callbacks
+
+    def _register_irq(self, button):
+        button.state = button.pin.value()
+        level = 1 if button.state == 0 else 0
+        # print(f"Registering {button.pin} for {level}")
+        tidal_helpers.set_lightsleep_irq(button.pin, level, _button_irq)
+
+    def check_for_interrupts(self):
+        if self._isr_flag:
+            self._isr_flag = False
+            uasyncio.create_task(self.check_buttons())
+            return True
+        else:
+            return False
+
+    async def check_buttons(self):
+        # print("Checking buttons...")
+        for button in self._callbacks.values():
+            new_state = button.pin.value()
+            if new_state != button.state:
+                # print(f"{button.pin} state changed to {new_state}")
+                button.state = new_state
+                if button.updown:
+                    button.callback(button.pin, button.state == 0)
+                elif button.state == 0:
+                    # Button pressed down
+                    button.callback(button.pin)
+
+                # Check that, if we made a callback, that it didn't unregister the button
+                if self._is_registered(button):
+                    # and if it didn't, re-enable the interrupt
+                    self._register_irq(button)
+
+            # if button.check_state() and self._is_registered(button):
+            # if self._is_registered(button) and button.should_autorepeat() and self._autorepeating_button == None:
+            #     self._autorepeating_button = button
+            #     self._timer.init(mode=Timer.ONE_SHOT, period=self.autorepeat_delay_time, callback=lambda t: self._autorepeat_delay_expired())
+
+
+
+    # def _irq_triggered(self, button):
+    #     # You can't actually trust button.pin.value() in an edge-triggered IRQ.
+    #     # The voltage at which it triggers is not necessarily the same as the
+    #     # 0-1 threshold, plus it depends how quickly this code gets to run
+    #     # versus how quickly the voltage changes. Use a short timer to handle
+    #     # this and provide a bit of debouncing as well
+
+    #     # Any further button event cancels any autorepeat
+    #     self._autorepeating_button = None
+
+    #     self._timer.init(mode=Timer.ONE_SHOT, period=10, callback=lambda t: self._timer_fired())
+
+    def _timer_fired(self):
+        ab = self._autorepeating_button
+        if ab:
+            ab.check_state()
+            if ab.state == 0:
+                # Still down
+                ab.callback(ab.pin)
+            if not self._is_registered(ab) or ab.state == 1:
+                # Stop repeating
+                self._timer.deinit()
+                self._autorepeating_button = None
+        else:
+            for button in self._callbacks.values():
+                button.check_state()
+                if self._is_registered(button) and button.should_autorepeat() and self._autorepeating_button == None:
+                    self._autorepeating_button = button
+                    self._timer.init(mode=Timer.ONE_SHOT, period=self.autorepeat_delay_time, callback=lambda t: self._autorepeat_delay_expired())
+
+    def _autorepeat_delay_expired(self):
+        if self._autorepeating_button:
+            self._timer.init(mode=Timer.PERIODIC, period=self._autorepeating_button.autorepeat, callback=lambda t: self._timer_fired())
+
+    def deactivate(self):
+        global _current
+        if not self.is_active():
+            return
+
+        print(f"Deactivating {self}")
+        self._timer.deinit()
+        self._autorepeating_button = None
+
+        for button in self._callbacks.values():
+            tidal_helpers.set_lightsleep_irq(button.pin, None, None)
+            if button.updown and button.state == 0:
+                # Simulate a button up
+                button.state = 1
+                button.callback(button.pin, False)
+
+        _current = None
+        self._isr_flag = False
+
+    def activate(self):
+        global _current
+        if _current:
+            _current.deactivate()
+        _current = self
+
+        print(f"Activating {self}")
+        for button in self._callbacks.values():
+            self._register_irq(button)
 
     def clear_callbacks(self):
-        self._press_callbacks[-1] = []
-
-    # TODO burn this once the IRQ stuff is sorted out
-    def poll(self):
-        for (pin, callback) in self._press_callbacks[-1]:
-            if pin.value() == 0:
-                callback(pin)
+        for button in self._callbacks.values():
+            self.on_press(button.pin, None)

--- a/modules/emflogo/__init__.py
+++ b/modules/emflogo/__init__.py
@@ -1,24 +1,25 @@
-from tidal import display, BUTTON_FRONT
-from app import App, task_coordinator
+from tidal import display
+from app import App
 import emf_png
-
 
 class EMFLogo(App):
     app_id = "emflogo"
-    post_wake_interval = interval = 0.01
 
-    def on_wake(self):
+    def on_start(self):
+        super().on_start()
+
+    def on_activate(self):
+        super().on_activate()
         display.vscrdef(40, 240, 40)
         display.vscsad(40)
         display.bitmap(emf_png, 0, 0)
         self.i = 0
+        self.timer_task = self.periodic(10, lambda: self.update())
 
     def update(self):
-        self.i += 1
-        if self.i >= 240:
-            self.i = 0
+        self.i = (self.i + 1) % 240
         display.vscsad(40 + self.i)
 
-        if BUTTON_FRONT.value() == 0:
-            display.vscsad(40)
-            task_coordinator.context_changed("menu")
+    def on_deactivate(self):
+        display.vscsad(40) # Scroll screen back up to top
+        self.timer_task.cancel()

--- a/modules/emflogo/__init__.py
+++ b/modules/emflogo/__init__.py
@@ -3,7 +3,6 @@ from app import App
 import emf_png
 
 class EMFLogo(App):
-    app_id = "emflogo"
 
     def on_start(self):
         super().on_start()
@@ -14,7 +13,7 @@ class EMFLogo(App):
         display.vscsad(40)
         display.bitmap(emf_png, 0, 0)
         self.i = 0
-        self.timer_task = self.periodic(10, lambda: self.update())
+        self.timer_task = self.periodic(10, self.update)
 
     def update(self):
         self.i = (self.i + 1) % 240

--- a/modules/hid/__init__.py
+++ b/modules/hid/__init__.py
@@ -4,7 +4,7 @@ import joystick
 from scheduler import get_scheduler
 
 class USBKeyboard(TextApp):
-    app_id = "keyboard"
+
     title = "USB Keyboard"
 
     def __init__(self):
@@ -29,7 +29,7 @@ class USBKeyboard(TextApp):
         window.println("cursor keys, A")
         window.println("and B are")
         window.println("themselves.")
-        get_scheduler().sleep_enabled = False
+        get_scheduler().set_sleep_enabled(False)
 
     def send_key(self, k, down):
         if down:

--- a/modules/otaupdate.py
+++ b/modules/otaupdate.py
@@ -1,27 +1,35 @@
 from tidal import *
-from buttons import Buttons
-from textwindow import TextWindow
-from app import App
+import textwindow
 from esp32 import Partition
 import network
 import ota
 import time
 
-class OtaUpdate(TextWindow, App):
+# Note, this intentionally doesn't inherit App or TextApp to limit dependencies
+# as this is on the critical path from the Recovery Menu.
+# But it acts sufficiently like it does, to satisfy the app launcher
+class OtaUpdate:
     
     app_id = "otaupdate"
-    interval = 0.2
+    title = "Firmware Update"
+    buttons = None
+    started = False
     
     BG = MAGENTA
     FG = WHITE
 
     confirmed = False
 
+    def run_sync(self):
+        self.on_start()
+        self.on_activate()
+
     def on_start(self):
-        self.cls()
-        self.println("OTA Update")
-        self.println("----------")
-        self.println()
+        self.window = textwindow.TextWindow(self.BG, self.FG, self.title)
+
+    def on_activate(self):
+        window = self.window
+        window.cls()
 
         try:
             current = Partition(Partition.RUNNING)
@@ -29,92 +37,107 @@ class OtaUpdate(TextWindow, App):
         except:
             # Hitting this likely means your partition table is out of date or
             # you're missing ota_data_initial.bin
-            self.println("No OTA info!")
-            self.println("USB flash needed")
+            window.println("No OTA info!")
+            window.println("USB flash needed")
             return
 
-        self.println("Boot: " + current.info()[4])
-        self.println("Next: " + nxt.info()[4])
-        self.println("Version:")
-        self.println(ota.get_version())
-        self.println()
-        line = self.get_next_line()
-        self.println("Press [A] to")
-        self.println("check updates.")
-        self.set_next_line(line)
+        window.println("Boot: " + current.info()[4])
+        window.println("Next: " + nxt.info()[4])
+        window.println("Version:")
+        window.println(ota.get_version())
+        window.println()
+        line = window.get_next_line()
+        window.println("Press [A] to")
+        window.println("check updates.")
 
-        self.buttons = Buttons()
-        self.buttons.on_press(BUTTON_A, lambda p: self.connect())
+        while BUTTON_A.value() == 1:
+            time.sleep(0.2)
 
-    def update(self):
-        self.buttons.poll()
+        window.clear_from_line(line)
+        self.connect()
 
     def connect(self):
-        self.buttons.clear_callbacks()
-
-        # Clear prompt
-        line = self.get_next_line()
-        self.println("", line)
-        self.println("", line + 1)
+        window = self.window
+        line = window.get_next_line()
 
         try:
             import wifi_cfg
-            self.println("Connecting...", line)
+            wifi_cfg.sta.status()
+        except Exception as e:
+            print(e)
+            window.println("No WIFI config!")
+            return
+
+        while True:
+            window.clear_from_line(line)
+            window.println("Connecting...", line)
             # Give WIFI chance to get IP address
-            for retry in range(0, 10):
+            for retry in range(0, 15):
                 stat = wifi_cfg.sta.status()
                 if stat == network.STAT_CONNECTING:
                     time.sleep(1.0)
                 else:
                     break
 
-            if wifi_cfg.sta.status() != network.STAT_GOT_IP:
-                self.println("Not connected!")
-                return
-            self.println("IP: {}".format(wifi_cfg.sta.ifconfig()[0]))
-        except Exception as e:
-            print(e)
-            self.println("No WIFI config!")
-            return
+            if wifi_cfg.sta.status() == network.STAT_GOT_IP:
+                break
+            else:
+                window.println("WiFi timed out", line)
+                window.println("[A] to retry", line + 1)
+                while BUTTON_A.value() == 1:
+                    time.sleep(0.2)
+                
+        window.println("IP:")
+        window.println(wifi_cfg.sta.ifconfig()[0])
 
         self.otaupdate()
 
     def otaupdate(self):
-        self.println()
-        self.println("Checking...", self.get_next_line())
+        window = self.window
+        window.println()
+        line = window.get_next_line()
 
-        try:
-            result = ota.update(lambda version, val: self.progress(version, val))
-        except OSError as e:
-            print("Error:" + str(e))
-            self.println("Update failed!")
-            self.println("Error {}".format(e.errno))
-            return
+        retry = True
+        while retry:
+            window.clear_from_line(line)
+            window.println("Checking...", line)
+
+            try:
+                result = ota.update(lambda version, val: self.progress(version, val))
+                retry = False
+            except OSError as e:
+                print("Error:" + str(e))
+                window.println("Update failed!")
+                window.println("Error {}".format(e.errno))
+                window.println("[A] to retry")
+                while BUTTON_A.value() == 1:
+                    time.sleep(0.2)
 
         if result:
-            self.println("Updated OK.")
-            self.println("Power cycle to")
-            self.println("finish update.")
+            window.println("Updated OK.")
+            window.println("Power cycle to")
+            window.println("finish update.")
         else:
-            self.println("Update cancelled")
+            window.println("Update cancelled")
 
     def progress(self, version, val):
+        window = self.window
         if not self.confirmed:
             if len(version) > 0:
-                self.println("New version:")
-                self.println(version)
-                self.println()
-                line = self.get_next_line()
-                self.println("Press [A] to")
-                self.println("confirm update.")
+                window.println("New version:")
+                window.println(version)
+                window.println()
+                line = window.get_next_line()
+                window.println("Press [A] to")
+                window.println("confirm update.")
                 while BUTTON_A.value() == 1:
                     time.sleep(0.2)
                 # Clear confirmation text
-                self.set_next_line(line)
+                window.set_next_line(line)
             self.confirmed = True
-            self.println("Updating...")
-            self.println()
+            window.println("Updating...")
+            window.println()
 
-        y = self.get_next_line() * (self.font.HEIGHT + 1)
-        display.fill_rect((self.width() - 100) // 2, y, val, self.font.HEIGHT, WHITE)
+        y = window.get_line_pos(window.get_next_line())
+        window.display.fill_rect((window.width() - 100) // 2, y, val, window.font.HEIGHT, WHITE)
         return True

--- a/modules/otaupdate.py
+++ b/modules/otaupdate.py
@@ -10,7 +10,6 @@ import time
 # But it acts sufficiently like it does, to satisfy the app launcher
 class OtaUpdate:
     
-    app_id = "otaupdate"
     title = "Firmware Update"
     buttons = None
     started = False
@@ -23,6 +22,9 @@ class OtaUpdate:
     def run_sync(self):
         self.on_start()
         self.on_activate()
+
+    def get_app_id(self):
+        return "otaupdate"
 
     def on_start(self):
         self.window = textwindow.TextWindow(self.BG, self.FG, self.title)
@@ -138,6 +140,5 @@ class OtaUpdate:
             window.println("Updating...")
             window.println()
 
-        y = window.get_line_pos(window.get_next_line())
-        window.display.fill_rect((window.width() - 100) // 2, y, val, window.font.HEIGHT, WHITE)
+        window.progress_bar(window.get_next_line(), val)
         return True

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -1,0 +1,133 @@
+import tidal_helpers
+import time
+import uasyncio
+
+_scheduler = None
+
+def get_scheduler():
+    global _scheduler
+    if not _scheduler:
+        _scheduler = Scheduler()
+    return _scheduler
+
+class TimerTask:
+    def __init__(self, main_task, fn, time_ticks, period_interval=None):
+        self.main_task = main_task
+        self.time_ticks = time_ticks
+        self.fn = fn
+        self.period_interval = period_interval
+
+    def cancel(self):
+        self.main_task.cancel_task(self)
+
+    async def async_call(self):
+        self.fn()
+
+class Scheduler:
+    
+    _current_app = None
+    _root_app = None
+    sleep_enabled = True
+
+    def __init__(self):
+        self._timers = []
+    
+    def switch_app(self, app):
+        uasyncio.create_task(self._switch_app(app))
+
+    async def _switch_app(self, app):
+        if app is None:
+            app = self._root_app
+        if app == self._current_app:
+            # Nothing to do
+            return
+        print(f"Switching app to {app.app_id}")
+
+        if app.buttons:
+            app.buttons.activate()
+        elif self._current_app and self._current_app.buttons:
+            # Then we'd better at least deactivate the current buttons
+            self._current_app.buttons.deactivate()
+
+        if self._current_app:
+            self._current_app.on_deactivate()
+
+        self._current_app = app
+        if not app.started:
+            app.started = True
+            app.on_start()
+        app.on_activate()
+
+    def get_next_sleep_time(self):
+        next_timer_task = self.peek_timer()
+        if next_timer_task:
+            next_time = next_timer_task.time_ticks
+            return max(1, next_time - time.ticks_ms())
+        else:
+            return 0
+
+    def main(self, initial_app):
+        self._root_app = initial_app
+        self.switch_app(initial_app)
+        tidal_helpers.esp_sleep_enable_gpio_wakeup()
+        first_time = True
+        while True:
+            while self.check_for_interrupts() or first_time:
+                first_time = False
+                uasyncio.run_until_complete()
+
+            if self.sleep_enabled:
+                t = self.get_next_sleep_time()
+                # print(f"Sleepy time {t}")
+                # Make sure any debug prints show up on the USB UART
+                tidal_helpers.uart_tx_flush(0)
+                wakeup_cause = tidal_helpers.lightsleep(t)
+                # print(f"Returned from lightsleep reason={wakeup_cause}")
+            else:
+                # Just spin
+                pass
+
+
+    def check_for_interrupts(self):
+        found = False
+        if self._current_app and self._current_app.check_for_interrupts():
+            found = True
+        t = time.ticks_ms()
+        while True:
+            task = self.peek_timer()
+            if task and task.time_ticks <= t:
+                # print(f"Timer ready at {task.time_ticks}")
+                found = True
+                del self._timers[0]
+                uasyncio.create_task(task.async_call())
+                if task.period_interval:
+                    task.time_ticks = task.time_ticks + task.period_interval
+                    self.add_timer_task(task)
+                continue # Check next timer in the queue
+            else:
+                break
+
+        return found
+
+    def add_timer_task(self, task):
+        self._timers.append(task)
+        self._timers.sort(key=lambda t: t.time_ticks)
+
+    def cancel_task(self, task):
+        self._timers.remove(task)
+
+    def peek_timer(self):
+        if len(self._timers) > 0:
+            return self._timers[0]
+        else:
+            return None
+
+    def after(self, ms, callback):
+        task = TimerTask(self, callback, time.ticks_ms() + ms)
+        self.add_timer_task(task)
+        return task
+
+    def periodic(self, ms, callback):
+        task = TimerTask(self, callback, time.ticks_ms() + ms, ms)
+        self.add_timer_task(task)
+        return task

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -5,34 +5,36 @@ import uasyncio
 _scheduler = None
 
 def get_scheduler():
+    """Return the global scheduler object."""
     global _scheduler
     if not _scheduler:
         _scheduler = Scheduler()
     return _scheduler
 
 class TimerTask:
-    def __init__(self, main_task, fn, time_ticks, period_interval=None):
-        self.main_task = main_task
-        self.time_ticks = time_ticks
+    def __init__(self, fn, target_time, period_interval=None):
+        self.scheduler = None
+        self.target_time = target_time
         self.fn = fn
         self.period_interval = period_interval
 
     def cancel(self):
-        self.main_task.cancel_task(self)
+        if self.scheduler:
+            self.scheduler.cancel_task(self)
 
     async def async_call(self):
         self.fn()
 
 class Scheduler:
-    
     _current_app = None
     _root_app = None
     sleep_enabled = True
 
     def __init__(self):
         self._timers = []
-    
+
     def switch_app(self, app):
+        """Asynchronously switch to the specified app."""
         uasyncio.create_task(self._switch_app(app))
 
     async def _switch_app(self, app):
@@ -41,7 +43,7 @@ class Scheduler:
         if app == self._current_app:
             # Nothing to do
             return
-        print(f"Switching app to {app.app_id}")
+        print(f"Switching app to {app.get_app_id()}")
 
         if app.buttons:
             app.buttons.activate()
@@ -58,15 +60,15 @@ class Scheduler:
             app.on_start()
         app.on_activate()
 
-    def get_next_sleep_time(self):
-        next_timer_task = self.peek_timer()
-        if next_timer_task:
-            next_time = next_timer_task.time_ticks
+    def _get_next_sleep_time(self):
+        if next_timer_task := self.peek_timer():
+            next_time = next_timer_task.target_time
             return max(1, next_time - time.ticks_ms())
         else:
             return 0
 
     def main(self, initial_app):
+        """Main entry point to the scheduler. Does not return."""
         self._root_app = initial_app
         self.switch_app(initial_app)
         tidal_helpers.esp_sleep_enable_gpio_wakeup()
@@ -76,32 +78,44 @@ class Scheduler:
                 first_time = False
                 uasyncio.run_until_complete()
 
+            t = self._get_next_sleep_time()
             if self.sleep_enabled:
-                t = self.get_next_sleep_time()
                 # print(f"Sleepy time {t}")
                 # Make sure any debug prints show up on the USB UART
                 tidal_helpers.uart_tx_flush(0)
                 wakeup_cause = tidal_helpers.lightsleep(t)
                 # print(f"Returned from lightsleep reason={wakeup_cause}")
             else:
-                # Just spin
-                pass
+                if t == 0:
+                    # Add a bit of a sleep (which uses less power than straight-up looping)
+                    time.sleep(0.1)
+                else:
+                    time.sleep(t / 1000)
 
+    def set_sleep_enabled(self, flag):
+        print(f"Light sleep enabled: {flag}")
+        self.sleep_enabled = flag
+
+    def is_sleep_enabled(self):
+        return self.sleep_enabled
 
     def check_for_interrupts(self):
+        """Check for any pending interrupts and schedule uasyncio tasks for them."""
         found = False
         if self._current_app and self._current_app.check_for_interrupts():
             found = True
         t = time.ticks_ms()
         while True:
             task = self.peek_timer()
-            if task and task.time_ticks <= t:
-                # print(f"Timer ready at {task.time_ticks}")
+            if task and task.target_time <= t:
+                # print(f"Timer ready at {task.target_time}")
                 found = True
                 del self._timers[0]
+                task.scheduler = None
                 uasyncio.create_task(task.async_call())
                 if task.period_interval:
-                    task.time_ticks = task.time_ticks + task.period_interval
+                    # Re-add the task with an updated target time
+                    task.target_time = task.target_time + task.period_interval
                     self.add_timer_task(task)
                 continue # Check next timer in the queue
             else:
@@ -111,7 +125,8 @@ class Scheduler:
 
     def add_timer_task(self, task):
         self._timers.append(task)
-        self._timers.sort(key=lambda t: t.time_ticks)
+        task.scheduler = self
+        self._timers.sort(key=lambda t: t.target_time)
 
     def cancel_task(self, task):
         self._timers.remove(task)
@@ -123,11 +138,11 @@ class Scheduler:
             return None
 
     def after(self, ms, callback):
-        task = TimerTask(self, callback, time.ticks_ms() + ms)
+        task = TimerTask(callback, time.ticks_ms() + ms)
         self.add_timer_task(task)
         return task
 
     def periodic(self, ms, callback):
-        task = TimerTask(self, callback, time.ticks_ms() + ms, ms)
+        task = TimerTask(callback, time.ticks_ms() + ms, ms)
         self.add_timer_task(task)
         return task

--- a/modules/textwindow.py
+++ b/modules/textwindow.py
@@ -15,8 +15,7 @@ class TextWindow:
         self.current_line = 0
         self.offset = 0
         self.display = tidal.display
-        if title:
-            self.title = title
+        self.title = title
 
     def width(self):
         return self.display.width()
@@ -63,7 +62,7 @@ class TextWindow:
             xpos = (w - text_width) // 2
         else:
             xpos = (w - self.width_chars() * self.font.WIDTH) // 2
-        self.display.fill_rect(0, ypos, w, self.font.HEIGHT, bg)
+        self.display.fill_rect(0, ypos, w, self.font.HEIGHT + 1, bg)
         self.display.text(self.font, text, xpos, ypos, fg, bg)
 
     def draw_title(self):
@@ -71,9 +70,12 @@ class TextWindow:
             title_lines = self.title.split("\n")
             for i, line in enumerate(title_lines):
                 self.draw_line(line, i * (self.font.HEIGHT + 1), self.fg, self.bg, True)
-            liney = len(title_lines) * (self.font.HEIGHT + 1) + 1
-            self.display.hline(0, liney, self.width(), self.fg)
-            self.offset = liney + 4
+            liney = len(title_lines) * (self.font.HEIGHT + 1)
+            w = self.width()
+            self.display.fill_rect(0, liney, w, 1, self.bg)
+            self.display.hline(0, liney + 1, w, self.fg)
+            self.display.fill_rect(0, liney + 2, w, 3, self.bg)
+            self.offset = liney + 5
 
     def set_title(self, title):
         self.title = title
@@ -88,15 +90,24 @@ class TextWindow:
     def get_line_pos(self, line):
         return self.offset + line * (self.font.HEIGHT + 1)
 
-class Menu(TextWindow):
+    def progress_bar(self, line, percentage, fg=None):
+        """Display a line-sized progress bar for a percentage value 0-100"""
+        if fg is None:
+            fg = self.fg
+        x = (self.width() - 100) // 2
+        y = self.get_line_pos(line)
+        self.display.fill_rect(x, y, percentage, self.font.HEIGHT, fg)
+        # In case progress goes down, clear the right-hand side of the line
+        self.display.fill_rect(x + percentage, y, self.width() - (x + percentage), self.font.HEIGHT, self.bg)
 
-    _focus_idx = 0
+class Menu(TextWindow):
 
     def __init__(self, bg, fg, focus_bg, focus_fg, title, choices, font=None):
         super().__init__(bg, fg, title, font)
         self.focus_fg = focus_fg
         self.focus_bg = focus_bg
         self.choices = choices
+        self._focus_idx = 0
 
     def choice_line_args(self, idx, focus=False):
         line_info = {
@@ -105,21 +116,35 @@ class Menu(TextWindow):
             "bg": self.focus_bg if focus else self.bg,
             "centre": False
         }
-        line_info.update(self.choices[idx][0])
+        args = self.choices[idx][0]
+        if isinstance(args, str):
+            args = { "text": args }
+        line_info.update(args)
         return line_info
 
     def focus_idx(self):
         return self._focus_idx
 
-    def set_focus_idx(self, i):
-        self.println(**self.choice_line_args(self._focus_idx, focus=False))
+    def set_focus_idx(self, i, redraw=True):
+        if redraw:
+            self.println(**self.choice_line_args(self._focus_idx, focus=False))
         self._focus_idx = i % len(self.choices)
-        self.println(**self.choice_line_args(self._focus_idx, focus=True))
+        if redraw:
+            self.println(**self.choice_line_args(self._focus_idx, focus=True))
+
+    def draw_choices(self):
+        for i in range(len(self.choices)):
+            self.println(**self.choice_line_args(i, focus=(i == self._focus_idx)))
 
     def cls(self):
-        super().cls()
-        for choice, callback in self.choices:
-            self.println(**choice)
-        if self.choices:
-            # Force redraw of highlight
-            self.set_focus_idx(self._focus_idx)
+        self.draw_title()
+        self.draw_choices()
+        self.clear_from_line(len(self.choices))
+
+    def set_choices(self, choices):
+        self.choices = choices
+        self.draw_choices()
+
+    def set(self, title, choices):
+        self.set_title(title)
+        self.set_choices(choices)

--- a/modules/textwindow.py
+++ b/modules/textwindow.py
@@ -1,19 +1,12 @@
-import time
-
 import tidal
 import vga1_8x8 as default_font
 
 class TextWindow:
-    BG = tidal.BLUE
-    FG = tidal.WHITE
-
-    title = None
-
-    def __init__(self, bg=None, fg=None, font=None):
+    def __init__(self, bg=None, fg=None, title=None, font=None):
         if bg is None:
-            bg = self.BG
+            bg = tidal.BLUE
         if fg is None:
-            fg = self.FG
+            fg = tidal.WHITE
         if font is None:
             font = default_font
         self.bg = bg
@@ -22,6 +15,8 @@ class TextWindow:
         self.current_line = 0
         self.offset = 0
         self.display = tidal.display
+        if title:
+            self.title = title
 
     def width(self):
         return self.display.width()
@@ -35,12 +30,20 @@ class TextWindow:
     def height_chars(self):
         return self.display.height() // self.font.HEIGHT
 
-    def cls(self, colour=None):
-        if colour is None:
-            colour = self.bg
-        self.display.fill(colour)
+    def cls(self):
+        self.display.fill(self.bg)
         self.current_line = 0
         self.draw_title()
+
+    def clear_from_line(self, line=None):
+        if line is None:
+            line = self.get_next_line()
+        else:
+            # Passing in a line also updates next_line
+            self.set_next_line(line)
+        y = self.get_line_pos(line)
+        h = self.height() - y
+        self.display.fill_rect(0, y, self.width(), h, self.bg)
 
     def println(self, text="", y=None, fg=None, bg=None, centre=False):
         if y is None:
@@ -76,31 +79,24 @@ class TextWindow:
         self.title = title
         self.draw_title()
 
-
     def set_next_line(self, next_line):
         self.current_line = next_line
 
     def get_next_line(self):
         return self.current_line
 
+    def get_line_pos(self, line):
+        return self.offset + line * (self.font.HEIGHT + 1)
 
 class Menu(TextWindow):
 
-    title = "TiDAL Menu"
     _focus_idx = 0
 
-    FOCUS_FG = tidal.BLACK
-    FOCUS_BG = tidal.CYAN
-
-    def __init__(self, *args, **kwargs):
-        self.focus_fg = kwargs.pop("focus_fg", self.FOCUS_FG)
-        self.focus_bg = kwargs.pop("focus_bg", self.FOCUS_BG)
-        super().__init__(*args, **kwargs)
-
-    choices = (
-        ({"text": "hello"}, lambda: print("hello")),
-        ({"text": "Goodbye"}, lambda: print("bye")),
-    )
+    def __init__(self, bg, fg, focus_bg, focus_fg, title, choices, font=None):
+        super().__init__(bg, fg, title, font)
+        self.focus_fg = focus_fg
+        self.focus_bg = focus_bg
+        self.choices = choices
 
     def choice_line_args(self, idx, focus=False):
         line_info = {
@@ -112,16 +108,12 @@ class Menu(TextWindow):
         line_info.update(self.choices[idx][0])
         return line_info
 
-    @property
     def focus_idx(self):
         return self._focus_idx
 
-    @focus_idx.setter
-    def focus_idx(self, i):
-        if i < 0 or i >= len(self.choices):
-            i = 0
+    def set_focus_idx(self, i):
         self.println(**self.choice_line_args(self._focus_idx, focus=False))
-        self._focus_idx = i
+        self._focus_idx = i % len(self.choices)
         self.println(**self.choice_line_args(self._focus_idx, focus=True))
 
     def cls(self):
@@ -129,4 +121,5 @@ class Menu(TextWindow):
         for choice, callback in self.choices:
             self.println(**choice)
         if self.choices:
-            self.focus_idx = self.focus_idx
+            # Force redraw of highlight
+            self.set_focus_idx(self._focus_idx)

--- a/modules/tidal.py
+++ b/modules/tidal.py
@@ -11,6 +11,14 @@ import _tidal_usb as usb
 import tidal_helpers
 
 
+"""
+NOTE: If you are using the automatic lightsleep (on by default) you should never
+leave any pins set to input without a pullup unless they are guaranteed not to change state
+(externally held high/low).
+
+This affects pins G0, G1, G2, G3 (GPIO18,GPIO17,GPIO4,GPIO5 respectively).
+"""
+
 _devkitpins={}
 
 _devkitpins["BTN_A"]=2
@@ -67,10 +75,10 @@ elif variant == "prototype":
 else:
     _hw = _productionpins
 
-G0 = Pin(_hw["G0"], Pin.IN)
-G1 = Pin(_hw["G1"], Pin.IN)
-G2 = Pin(_hw["G2"], Pin.IN)
-G3 = Pin(_hw["G3"], Pin.IN)
+G0 = Pin(_hw["G0"], Pin.IN, Pin.PULL_UP)
+G1 = Pin(_hw["G1"], Pin.IN, Pin.PULL_UP)
+G2 = Pin(_hw["G2"], Pin.IN, Pin.PULL_UP)
+G3 = Pin(_hw["G3"], Pin.IN, Pin.PULL_UP)
 
 BUTTON_A = Pin(_hw["BTN_A"], Pin.IN, Pin.PULL_UP)
 BUTTON_B = Pin(_hw["BTN_B"], Pin.IN, Pin.PULL_UP)
@@ -132,7 +140,7 @@ def lcd_backlight_on(on=True):
     if(on):
         _LCD_BLEN.init(mode=Pin.OUT,value=0)
     else:
-        _LCD_BLEN.init(mode=Pin.IN,pull=None)
+        _LCD_BLEN.init(mode=Pin.IN,pull=Pin.PULL_UP)
         
 def lcd_backlight_off():
     lcd_backlight_on(False)

--- a/modules/tidal.py
+++ b/modules/tidal.py
@@ -201,3 +201,4 @@ def power_test_sequence(): #value without/with DFS
     time.sleep(0.1)
     machine.deepsleep(5000)#0.1
     
+TIMER_ID_BUTTONS = 3

--- a/modules/torch/__init__.py
+++ b/modules/torch/__init__.py
@@ -1,7 +1,5 @@
 from tidal import *
-from buttons import Buttons
-from textwindow import TextWindow
-from app import App, task_coordinator
+from app import TextApp
 
 BRIGHTNESS_STEP = 0.8
 HUE_STEP = 0.125
@@ -54,7 +52,7 @@ def rgbToHsv(r, g, b):
     return (h, s, v)
 
 
-class Torch(TextWindow, App):
+class Torch(TextApp):
     
     app_id = "torch"
     title = "Torch"
@@ -64,25 +62,26 @@ class Torch(TextWindow, App):
     FG = st7789.WHITE
 
     def update_screen(self, full=True):
+        win = self.window
         if full:
-            self.cls()
-            self.println("Press Joystick")
-            self.println("or A for on/off")
-            self.println()
-            self.println("Joystick up/down")
-            self.println("for brightness.")
-            self.println()
-            self.println("Left/right for")
-            self.println("colour.")
-            self.println()
+            win.cls()
+            win.println("Press Joystick")
+            win.println("or A for on/off")
+            win.println()
+            win.println("Joystick up/down")
+            win.println("for brightness.")
+            win.println()
+            win.println("Left/right for")
+            win.println("colour.")
+            win.println()
             # window.println("B for pattern")
             
-        self.println("LED: {}".format("ON" if self.state else "OFF"), 12)
+        win.println("LED: {}".format("ON" if self.state else "OFF"), 12)
         if self.led_h < 0:
-            self.println("Colour: WHITE", 13)
+            win.println("Colour: WHITE", 13)
         else:
-            self.println("Colour: Hue={}'".format(int(self.led_h * 360)), 13)
-        self.println("Brightness: {}%".format(int(self.led_v * 100)), 14)
+            win.println("Colour: Hue={}'".format(int(self.led_h * 360)), 13)
+        win.println("Brightness: {}%".format(int(self.led_v * 100)), 14)
 
     def update_led(self):
         if self.led_h >= 0:
@@ -126,28 +125,21 @@ class Torch(TextWindow, App):
         self.update_led()
 
     def on_start(self):
+        super().on_start()
         self.state = False
         self.led_h = HUE_WHITE
         self.led_v = 1.0
-        self.buttons = None
         self.led = led
 
-        buttons = Buttons()
-        buttons.on_press(JOY_CENTRE, self.toggle_led)
-        buttons.on_press(BUTTON_A, self.toggle_led)
-        buttons.on_press(JOY_UP, self.brightness_up)
-        buttons.on_press(JOY_DOWN, self.brightness_down)
-        buttons.on_press(JOY_LEFT, lambda p: self.hue_step(-HUE_STEP))
-        buttons.on_press(JOY_RIGHT, lambda p: self.hue_step(HUE_STEP))
-        self.buttons = buttons
+        self.buttons.on_press(JOY_CENTRE, self.toggle_led)
+        self.buttons.on_press(BUTTON_A, self.toggle_led)
+        self.buttons.on_press(JOY_UP, self.brightness_up)
+        self.buttons.on_press(JOY_DOWN, self.brightness_down)
+        self.buttons.on_press(JOY_LEFT, lambda p: self.hue_step(-HUE_STEP))
+        self.buttons.on_press(JOY_RIGHT, lambda p: self.hue_step(HUE_STEP))
 
-    def on_wake(self):
+    def on_activate(self):
+        super().on_activate()
         self.update_led()
         self.update_screen()
-
-    def update(self):
-        self.buttons.poll()
-        self.update_screen(full=False)
-        if BUTTON_FRONT.value() == 0:
-            task_coordinator.context_changed("menu")
 

--- a/modules/torch/__init__.py
+++ b/modules/torch/__init__.py
@@ -54,7 +54,6 @@ def rgbToHsv(r, g, b):
 
 class Torch(TextApp):
     
-    app_id = "torch"
     title = "Torch"
     interval = 0.2
     

--- a/modules/web_repl/__init__.py
+++ b/modules/web_repl/__init__.py
@@ -43,7 +43,7 @@ ap.config(essid=ssid, password=password)
         window.println("")
         window.println("Password: ")
         window.println(getattr(wifi_cfg, "password", "?"))
-        get_scheduler().sleep_enabled = False
+        get_scheduler().set_sleep_enabled(False)
 
         import esp
         esp.osdebug(None)

--- a/modules/web_repl/__init__.py
+++ b/modules/web_repl/__init__.py
@@ -1,12 +1,12 @@
-from app import App, task_coordinator
-from textwindow import TextWindow
-from tidal import BUTTON_FRONT
+from app import TextApp
+from scheduler import get_scheduler
 
-class WebRepl(App, TextWindow):
+class WebRepl(TextApp):
 
     title = "Web REPL"
 
     def on_start(self):
+        super().on_start()
         try:
             with open("webrepl_cfg.py") as f:
                 pass
@@ -32,24 +32,20 @@ ap.active(True)
 ap.config(essid=ssid, password=password)
 """)
 
-
-    def on_wake(self):
-        self.cls()
+    def on_activate(self):
+        super().on_activate()
+        window = self.window
+        window.cls()
         import wifi_cfg
 
-        self.println("SSID:")
-        self.println(getattr(wifi_cfg, "ssid", "?"))
-        self.println("")
-        self.println("Password: ")
-        self.println(getattr(wifi_cfg, "password", "?"))
+        window.println("SSID:")
+        window.println(getattr(wifi_cfg, "ssid", "?"))
+        window.println("")
+        window.println("Password: ")
+        window.println(getattr(wifi_cfg, "password", "?"))
+        get_scheduler().sleep_enabled = False
 
         import esp
         esp.osdebug(None)
         import webrepl
         webrepl.start()
-
-    def update(self):
-        if BUTTON_FRONT.value() == 0:
-            import webrepl
-            webrepl.stop()
-            task_coordinator.context_changed("menu")


### PR DESCRIPTION
Apps are now single-inheritance because micropython doesn't support
multiple inheritance initialisers (plus it's a bit simpler for app
writers).

All apps (except ones that need to synchronously poll for response in
a low tech fashion, like otaupdate) now use callbacks for button press
events, and own a Buttons object (self.buttons) set up in the App
constructor. Apps which require USB or WiFi need to set
`get_scheduler().sleep_enabled = False` to prevent lightsleep from being
entered.