### PR TITLE
Add release action including micropython.bin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
   workflow_dispatch:
   push:
-    branches: main
+    tags:
+      - "v*"
 jobs:
   Build-Firmware:
     runs-on: ubuntu-latest
@@ -58,12 +59,19 @@ jobs:
             micropython/ports/esp32/build-tildamk6/bootloader/bootloader.bin
             micropython/ports/esp32/build-tildamk6/partition_table/partition-table.bin
             micropython/ports/esp32/build-tildamk6/ota_data_initial.bin
-      - name: Create release
+      - name: Create latest release for tags
         uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.event_name == 'push'
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           automatic_release_tag: "latest"
-          prerelease: true
-          title: "Development Build"
+          title: "Latest release build"
+          files: |
+            micropython/ports/esp32/build-tildamk6/micropython.bin
+      - name: Create specific release for tags
+        uses: "marvinpinto/action-automatic-releases@latest"
+        if: github.event_name == 'push'
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
           files: |
             micropython/ports/esp32/build-tildamk6/micropython.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,12 @@ jobs:
             micropython/ports/esp32/build-tildamk6/bootloader/bootloader.bin
             micropython/ports/esp32/build-tildamk6/partition_table/partition-table.bin
             micropython/ports/esp32/build-tildamk6/ota_data_initial.bin
+      - name: Create release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "latest"
+          prerelease: true
+          title: "Development Build"
+          files: |
+            micropython/ports/esp32/build-tildamk6/micropython.bin

--- a/drivers/ota/ota.c
+++ b/drivers/ota/ota.c
@@ -7,7 +7,7 @@
 
 // static const char *TAG = "ota";
 
-#define IMAGE_URL "https://raw.githubusercontent.com/tomsci/tidal-ota/main/micropython.bin"
+#define IMAGE_URL "https://github.com/emfcamp/TiDAL-Firmware/releases/download/latest/micropython.bin"
 
 // openssl x509 -text -inform DER -in "DigiCert Global Root CA.cer"
 static const char kGithubCertificate[] =
@@ -38,6 +38,9 @@ STATIC mp_obj_t ota_update(mp_obj_t cb_obj) {
     esp_http_client_config_t config = {
         .url = IMAGE_URL,
         .cert_pem = kGithubCertificate,
+        // This buffer must be big enough to contain any individual request header
+        // We are redirected to an S3 signed URL that is 548 bytes long!!
+        .buffer_size_tx = 768,
     };
     esp_https_ota_config_t ota_config = {
         .http_config = &config,


### PR DESCRIPTION
This is to support OTA, but we'd only really want to build OTAs from tags, so this is more proof that it works. We can change the triggers later.