### PR TITLE
Add micropython-lib and freeze urequests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "st7789"]
 	path = st7789
 	url = git@github.com:russhughes/st7789_mpy.git
+[submodule "micropython-lib"]
+	path = micropython-lib
+	url = git@github.com:micropython/micropython-lib.git

--- a/tildamk6/manifest.py
+++ b/tildamk6/manifest.py
@@ -43,6 +43,7 @@ freeze("$(MPY_DIR)/ports/esp8266/modules", "ntptime.py")
 freeze("$(MPY_DIR)/drivers/dht", "dht.py")
 freeze("$(MPY_DIR)/drivers/onewire")
 freeze("$(MPY_DIR)/../modules")
+freeze("$(MPY_DIR)/../micropython-lib/python-ecosys/urequests", "urequests.py")
 freeze_images("$(MPY_DIR)/../modules", "$(PORT_DIR)/build-tildamk6/modules_generated")
 
 freeze("$(MPY_DIR)/../st7789/fonts/bitmap", "vga1_8x8.py")


### PR DESCRIPTION
People building apps will probably want to do HTTP requests. urequests is a great starting point there, and there may be more in micropython-lib we want to include.