### PR TITLE
Do not enter lightsleep when USB is plugged in

### DIFF
--- a/drivers/tidal_helpers/tidal_helpers.c
+++ b/drivers/tidal_helpers/tidal_helpers.c
@@ -9,7 +9,6 @@
 #include "rom/uart.h"
 
 static const char *TAG = "tidal_helpers";
-time_t no_sleep_before = 0;
 
 // Have to redefine this from machine_pin.c, unfortunately
 typedef struct _machine_pin_obj_t {
@@ -50,44 +49,14 @@ STATIC mp_obj_t tidal_esp_sleep_enable_gpio_wakeup() {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(tidal_esp_sleep_enable_gpio_wakeup_obj, tidal_esp_sleep_enable_gpio_wakeup);
 
-// inhibit_sleep() -> None : Prevent sleep for the next 15 seconds
-STATIC mp_obj_t tidal_helper_inhibit_sleep() {
-    time_t now;
-    time(&now);
-    no_sleep_before = now + 15;
-    ESP_LOGE(TAG, "Now %lu, No sleep before %lu", now, no_sleep_before);
-    return mp_const_none;
+// usb_connected() -> bool : Returns True if any USB packets have been received since last usb reset
+STATIC mp_obj_t tidal_helper_usb_connected() {
+    if (tud_connected())
+        return mp_const_true;
+    else
+        return mp_const_false;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(tidal_helper_inhibit_sleep_obj, tidal_helper_inhibit_sleep);
-
-// can_sleep() -> bool : Returns False if sleep is prevented by USB state
-STATIC mp_obj_t tidal_helper_can_sleep() {
-    // The devboard should not go into light sleep as it has no CHARGE_DET to wake from
-    #if defined(CONFIG_TIDAL_VARIANT_DEVBOARD)
-        return mp_const_false;
-    #endif
-    
-    // Do not sleep if we have a bound on sleep time from an interrupt
-    time_t now;
-    time(&now);
-    if (now < no_sleep_before) {
-        return mp_const_false;
-    }
-    
-    // Any activity on USB since last usb reset blocks sleep
-    if (tud_connected()) {
-        return mp_const_false;
-    }
-    
-    // Active WIFI usage blocks sleep
-    wifi_mode_t wifi_mode;
-    esp_err_t ok = esp_wifi_get_mode(&wifi_mode);
-    if (ok == ESP_OK && wifi_mode != WIFI_MODE_NULL) {
-        return mp_const_false;
-    }
-    return mp_const_true;
-}
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(tidal_helper_can_sleep_obj, tidal_helper_can_sleep);
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(tidal_helper_usb_connected_obj, tidal_helper_usb_connected);
 
 STATIC mp_obj_t tidal_esp_sleep_pd_config(mp_obj_t domain_obj, mp_obj_t option_obj) {
     esp_sleep_pd_domain_t domain = (esp_sleep_pd_domain_t)mp_obj_get_int(domain_obj);
@@ -262,8 +231,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(tidal_pin_number_obj, tidal_pin_number);
 STATIC const mp_rom_map_elem_t tidal_helpers_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ota) },
     { MP_ROM_QSTR(MP_QSTR_get_variant), MP_ROM_PTR(&tidal_helper_get_variant_obj) },
-    { MP_ROM_QSTR(MP_QSTR_can_sleep), MP_ROM_PTR(&tidal_helper_can_sleep_obj) },
-    { MP_ROM_QSTR(MP_QSTR_inhibit_sleep), MP_ROM_PTR(&tidal_helper_inhibit_sleep_obj) },
+    { MP_ROM_QSTR(MP_QSTR_usb_connected), MP_ROM_PTR(&tidal_helper_usb_connected_obj) },
     { MP_ROM_QSTR(MP_QSTR_esp_sleep_enable_gpio_wakeup), MP_ROM_PTR(&tidal_esp_sleep_enable_gpio_wakeup_obj) },
     { MP_ROM_QSTR(MP_QSTR_esp_sleep_pd_config), MP_ROM_PTR(&tidal_esp_sleep_pd_config_obj) },
     { MP_ROM_QSTR(MP_QSTR_gpio_wakeup), MP_ROM_PTR(&tidal_gpio_wakeup_obj) },

--- a/drivers/tidal_helpers/tidal_helpers.c
+++ b/drivers/tidal_helpers/tidal_helpers.c
@@ -4,6 +4,7 @@
 #include "mphalport.h"
 #include "modmachine.h" // for machine_pin_type
 #include "esp_sleep.h"
+#include "device/usbd.h"
 #include "rom/uart.h"
 
 // Have to redefine this from machine_pin.c, unfortunately
@@ -188,7 +189,8 @@ STATIC mp_obj_t tidal_lightsleep(mp_obj_t time_obj) {
         esp_sleep_enable_timer_wakeup(((uint64_t)time_ms) * 1000);
     }
 
-    esp_light_sleep_start();
+    if (!tud_connected())
+        esp_light_sleep_start();
 
     if (time_ms) {
         // Reset this

--- a/modules/boot.py
+++ b/modules/boot.py
@@ -6,6 +6,7 @@ from esp32 import Partition
 tidal_helpers.esp_sleep_enable_gpio_switch(False)
 
 # Initialize USB early on
+tidal_helpers.inhibit_sleep()
 tidal.usb.initialize()
 tidal.init_lcd()
 

--- a/modules/boot.py
+++ b/modules/boot.py
@@ -1,12 +1,12 @@
 import tidal
 import tidal_helpers
+import scheduler
 from esp32 import Partition
 
 # sleep_sel just gets in the way of using lightsleep
 tidal_helpers.esp_sleep_enable_gpio_switch(False)
 
 # Initialize USB early on
-tidal_helpers.inhibit_sleep()
 tidal.usb.initialize()
 tidal.init_lcd()
 
@@ -17,6 +17,11 @@ if tidal.BUTTON_FRONT.value() == 0:
 else:
     from app_launcher import Launcher
     menu = Launcher()
+    # Prevent USB sleep for 15 seconds if we're
+    # going to launch the main menu.
+    scheduler = scheduler.get_scheduler()
+    scheduler.inhibit_sleep()
+
 
 # If we've made it to here, any OTA update has _probably_ gone ok...
 Partition.mark_app_valid_cancel_rollback()

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -115,7 +115,7 @@ class Scheduler:
         self.sleep_enabled = flag
 
     def is_sleep_enabled(self):
-        return self.sleep_enabled
+        return self.sleep_enabled and tidal_helpers.can_sleep()
 
     def check_for_interrupts(self):
         """Check for any pending interrupts and schedule uasyncio tasks for them."""

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -35,6 +35,7 @@ class Scheduler:
     _current_app = None
     _root_app = None
     sleep_enabled = True
+    no_sleep_before = 0
 
     def __init__(self):
         self._timers = []
@@ -94,7 +95,7 @@ class Scheduler:
                 break
 
             t = self._get_next_sleep_time()
-            if self.sleep_enabled:
+            if self.is_sleep_enabled():
                 # print(f"Sleepy time {t}")
                 # Make sure any debug prints show up on the USB UART
                 tidal_helpers.uart_tx_flush(0)
@@ -114,8 +115,17 @@ class Scheduler:
         print(f"Light sleep enabled: {flag}")
         self.sleep_enabled = flag
 
+    def inhibit_sleep(self):
+        now = time.ticks_ms()
+        self.no_sleep_before = now + 15000
+
     def is_sleep_enabled(self):
-        return self.sleep_enabled and tidal_helpers.can_sleep()
+        return (
+            self.sleep_enabled and
+            tidal_helpers.get_variant() != "devboard" and
+            not tidal_helpers.usb_connected() and
+            time.ticks_ms() >= self.no_sleep_before
+        )
 
     def check_for_interrupts(self):
         """Check for any pending interrupts and schedule uasyncio tasks for them."""


### PR DESCRIPTION
This prevents calls to tidal.lightsleep(...) from actually entering lightsleep if any bytes have been received over the USB interface since the  last reset.