### PR TITLE
Add inactivity timer to switch screen off

### DIFF
--- a/modules/app_launcher/__init__.py
+++ b/modules/app_launcher/__init__.py
@@ -92,6 +92,5 @@ class Launcher(MenuApp):
         self.set_rotation((self.get_rotation() + 90) % 360)
 
     def charge_state_changed(self, charging):
-        # We'll only hit this if Scheduler.should_sleep() is false
-        # print(f"Launcher CHARGE_DET charging={charging}")
         self.update_title(redraw=True)
+        get_scheduler().usb_plug_event(charging)

--- a/modules/app_launcher/__init__.py
+++ b/modules/app_launcher/__init__.py
@@ -1,4 +1,5 @@
 import tidal
+import tidal_helpers
 from app import MenuApp
 from scheduler import get_scheduler
 import emf_png
@@ -19,7 +20,7 @@ class Launcher(MenuApp):
         # Note, the text for each choice needs to be <= 16 characters in order to fit on screen
         return (
             ("USB Keyboard", lambda: self.launch("hid", "USBKeyboard")),
-            ("Web REPL", lambda: self.launch("web_repl", "WebRepl")),
+            # ("Web REPL", lambda: self.launch("web_repl", "WebRepl")),
             ("Torch", lambda: self.launch("torch", "Torch")),
             ("Logo", lambda: self.launch("emflogo", "EMFLogo")),
             ("Update Firmware", lambda: self.launch("otaupdate", "OtaUpdate")),
@@ -40,6 +41,9 @@ class Launcher(MenuApp):
         super().on_start()
         self.window.set_choices(self.choices, redraw=False)
         self.buttons.on_press(tidal.BUTTON_B, self.rotate)
+        self.buttons.on_up_down(tidal.CHARGE_DET, self.charge_state_changed)
+        self.buttons.on_press(tidal.BUTTON_FRONT, lambda: self.update_title(redraw=True))
+
         initial_item = 0
         try:
             with open("/lastapplaunch.txt") as f:
@@ -55,13 +59,23 @@ class Launcher(MenuApp):
             tidal.display.bitmap(emf_png, 0, 0)
             self.after(SPLASHSCREEN_TIME, lambda: self.dismiss_splash())
         else:
-            if not get_scheduler().is_sleep_enabled():
-                self.window.set_title(self.TITLE + "\nSLEEP DISABLED", redraw=False)
+            self.update_title(redraw=False)
             super().on_activate()
 
     def dismiss_splash(self):
         self.show_splash = False
         self.on_activate()
+
+    def update_title(self, redraw):
+        title = self.TITLE
+        if not get_scheduler().is_sleep_enabled():
+            title += "\nSLEEP DISABLED"
+        pwr = tidal.CHARGE_DET.value() == 0 and 1 or 0
+        conn = tidal_helpers.usb_connected() and 1 or 0
+        if pwr or conn:
+            title += f"\nUSB pwr={pwr} conn={conn}"
+        if title != self.window.title:
+            self.window.set_title(title, redraw=redraw)
 
     def launch(self, module_name, app_name):
         app = self._apps.get(app_name)
@@ -76,3 +90,8 @@ class Launcher(MenuApp):
 
     def rotate(self):
         self.set_rotation((self.get_rotation() + 90) % 360)
+
+    def charge_state_changed(self, charging):
+        # We'll only hit this if Scheduler.should_sleep() is false
+        # print(f"Launcher CHARGE_DET charging={charging}")
+        self.update_title(redraw=True)

--- a/modules/boot.py
+++ b/modules/boot.py
@@ -1,6 +1,5 @@
 import tidal
 import tidal_helpers
-import scheduler
 from esp32 import Partition
 
 # sleep_sel just gets in the way of using lightsleep
@@ -17,10 +16,6 @@ if tidal.BUTTON_FRONT.value() == 0:
 else:
     from app_launcher import Launcher
     menu = Launcher()
-    # Prevent USB sleep for 15 seconds if we're
-    # going to launch the main menu.
-    scheduler = scheduler.get_scheduler()
-    scheduler.inhibit_sleep()
 
 
 # If we've made it to here, any OTA update has _probably_ gone ok...

--- a/modules/buttons.py
+++ b/modules/buttons.py
@@ -51,6 +51,8 @@ class Buttons:
         self._autorepeating_button = None
         self._isr_flag = False
         self._rotation = tidal.get_display_rotation()
+        # This doesn't seem like the best place to put this, but I can't think of a better offhand
+        self.on_up_down(tidal.CHARGE_DET, get_scheduler().usb_plug_event)
 
     def is_active(self):
         return _current == self

--- a/modules/hid/__init__.py
+++ b/modules/hid/__init__.py
@@ -1,7 +1,6 @@
 from tidal import *
 from app import TextApp
 import joystick
-from scheduler import get_scheduler
 
 class USBKeyboard(TextApp):
 
@@ -29,7 +28,6 @@ class USBKeyboard(TextApp):
         window.println("cursor keys, A")
         window.println("and B are")
         window.println("themselves.")
-        get_scheduler().set_sleep_enabled(False)
 
     def send_key(self, k, down):
         if down:

--- a/modules/scheduler.py
+++ b/modules/scheduler.py
@@ -1,9 +1,13 @@
+import settings
 import tidal
 import tidal_helpers
 import time
 import uasyncio
+import wifi
 
 _scheduler = None
+
+_FAR_FUTURE = const(2**63)
 
 def get_scheduler():
     """Return the global scheduler object."""
@@ -36,10 +40,19 @@ class Scheduler:
     _current_app = None
     _root_app = None
     sleep_enabled = True
-    no_sleep_before = 0
 
     def __init__(self):
         self._timers = []
+        self.no_sleep_before = time.ticks_ms() + (settings.get("boot_nosleep_time", 15) * 1000)
+        # Could do this more directly, but this is easy
+        import buttons
+        self._wake_lcd_buttons = buttons.Buttons()
+        for button in tidal.ALL_BUTTONS:
+            # We don't need these button presses to do anything, they just have to exist
+            self._wake_lcd_buttons.on_press(button, lambda: 0)
+        # CHARGE_DET isn't a button, but Buttons.on_up_down works for any GPIO
+        # in a way compatible with lightsleep, so it's convenient
+        self._wake_lcd_buttons.on_up_down(tidal.CHARGE_DET, self._usb_plug_event)
 
     def switch_app(self, app):
         """Asynchronously switch to the specified app."""
@@ -71,25 +84,21 @@ class Scheduler:
             app.on_start()
         app.on_activate()
 
-    def _get_next_sleep_time(self):
-        if next_timer_task := self.peek_timer():
-            next_time = next_timer_task.target_time
-            return max(1, next_time - time.ticks_ms())
-        else:
-            return 0
-
     def main(self, initial_app):
         """Main entry point to the scheduler. Does not return."""
         self._root_app = initial_app
         self.switch_app(initial_app)
         tidal_helpers.esp_sleep_enable_gpio_wakeup()
         self._level = 0
+        self.reset_inactivity()
         self.enter()
 
     def enter(self): 
+        import buttons
         first_time = True
         self._level += 1
         enter_level = self._level
+        deactivated_app = None
         while True:
             while self.check_for_interrupts() or first_time:
                 first_time = False
@@ -98,19 +107,63 @@ class Scheduler:
             if self._level < enter_level:
                 break
 
-            t = self._get_next_sleep_time()
-            if self.is_sleep_enabled():
+            # Work out when we need to sleep until
+            now = time.ticks_ms()
+            lcd_sleep_time = self._last_activity_time + self.get_inactivity_time()
+            should_sleep_lcd = lcd_sleep_time <= now
+            can_sleep = self.can_sleep()
+            if can_sleep and should_sleep_lcd:
+                # Then we have to notify the app that we're going to switch off
+                # the LCD, which might alter the next timer wakeup if the app
+                # has timers it cancels in its on_deactivate(), hence why we do
+                # this before calling peek_timer()
+                deactivated_app = self._current_app
+                if deactivated_app:
+                    deactivated_app.on_deactivate()
+
+            if next_timer_task := self.peek_timer():
+                next_time = next_timer_task.target_time
+            else:
+                next_time = _FAR_FUTURE
+
+            # Force a wake when the screen is due to switch off
+            if now < lcd_sleep_time:
+                next_time = min(next_time, lcd_sleep_time)
+
+            if next_time <= now:
+                # Oops we missed a timer, continue to go back to check_for_interrupts() at top of loop
+                continue
+            elif next_time == _FAR_FUTURE:
+                t = 0
+            else:
+                t = next_time - now
+
+            if can_sleep:
                 # print(f"Sleepy time {t}")
                 # Make sure any debug prints show up on the USB UART
                 tidal_helpers.uart_tx_flush(0)
+                if should_sleep_lcd:
+                    tidal.lcd_power_off()
+                    # Switch buttons so that (a) a press while the screen is off
+                    # doesn't get passed to the app, and (b) so that any button
+                    # wakes the screen, even ones the app hasn't registered an
+                    # interrupt for.
+                    self._wake_lcd_buttons.activate()
+
                 wakeup_cause = tidal_helpers.lightsleep(t)
                 # print(f"Returned from lightsleep reason={wakeup_cause}")
+
+                if deactivated_app:
+                    # This will also reactivate its buttons
+                    deactivated_app.on_activate()
+                    deactivated_app = None
+
             else:
                 if t == 0:
                     # Add a bit of a sleep (which uses less power than straight-up looping)
-                    time.sleep(0.1)
-                else:
-                    time.sleep(t / 1000)
+                    t = 100
+                # Don't sleep for more than 0.1s otherwise buttons will be unresponsive
+                time.sleep(min(0.1, t / 1000))
 
     def exit(self):
         self._level = self._level - 1
@@ -119,24 +172,35 @@ class Scheduler:
         print(f"Light sleep enabled: {flag}")
         self.sleep_enabled = flag
 
-    def inhibit_sleep(self):
-        now = time.ticks_ms()
-        self.no_sleep_before = now + 15000
-
     def is_sleep_enabled(self):
+        return self.sleep_enabled
+
+    def can_sleep(self):
         return (
             self.sleep_enabled and
             tidal_helpers.get_variant() != "devboard" and
             not tidal_helpers.usb_connected() and
+            not wifi.active() and
             time.ticks_ms() >= self.no_sleep_before
         )
 
     def reset_inactivity(self):
-        pass # TODO!
+        # print("Reset inactivity")
+        self._last_activity_time = time.ticks_ms()
+        tidal.lcd_power_on()
+
+    def _usb_plug_event(self, charging):
+        # We don't actually have to do anything here, the side effect of Buttons
+        # calling reset_inactivity is all we needed
+        # print(f"CHARGE_DET charging={charging}")
+        pass
+
+    def get_inactivity_time(self):
+        return settings.get("inactivity_time", 30) * 1000
 
     def check_for_interrupts(self):
         """Check for any pending interrupts and schedule uasyncio tasks for them."""
-        found = False
+        found = self._wake_lcd_buttons.check_for_interrupts()
         if self._current_app and self._current_app.check_for_interrupts():
             found = True
         t = time.ticks_ms()

--- a/modules/textwindow.py
+++ b/modules/textwindow.py
@@ -21,6 +21,7 @@ class TextWindow:
         self.current_line = 0
         self.pos_y = 0
         self.display = tidal.display
+        self.line_offset = None
         self.set_title(title, redraw=False)
         self.buttons = buttons
 
@@ -106,12 +107,17 @@ class TextWindow:
 
     def set_title(self, title, redraw=True):
         self.title = title
+        prev_line_offset = self.line_offset
         if title is None:
             self.line_offset = 0
         else:
             self.line_offset = len(title.split("\n")) * self.line_height() + 5
         if redraw:
-            self.draw_title()
+            if prev_line_offset is None or self.line_offset == prev_line_offset:
+                self.draw_title()
+            else:
+                # A full redraw is needed if the height of the title has changed
+                self.redraw()
 
     def set_next_line(self, next_line):
         self.current_line = next_line

--- a/modules/wifi.py
+++ b/modules/wifi.py
@@ -33,6 +33,9 @@ def accesspoint_get_ip():
     else:
         return None
 
+def active():
+    return _STA_IF.active()
+
 def save_defaults(ssid, password):
     settings.set("wifi_ssid", ssid)
     settings.set("wifi_password", password)
@@ -67,13 +70,14 @@ def disconnect():
     '''
     Disconnect from the WiFi network
     '''
-    _STA_IF.disconnect()
+    if _STA_IF.status() != network.STAT_IDLE:
+        _STA_IF.disconnect()
 
 def stop():
     '''
     Disconnect from the WiFi network and disable the station interface
     '''
-    _STA_IF.disconnect()
+    disconnect()
     _STA_IF.active(False)
 
 def status():

--- a/modules/wifi_client/__init__.py
+++ b/modules/wifi_client/__init__.py
@@ -3,7 +3,6 @@ import network
 import settings
 import wifi
 from app import MenuApp
-from scheduler import get_scheduler
 
 class WifiClient(MenuApp):
     
@@ -53,7 +52,6 @@ class WifiClient(MenuApp):
 
     def on_start(self):
         super().on_start()
-        get_scheduler().set_sleep_enabled(False)
         self.wifi_networks = []
         if ssid := wifi.get_default_ssid():
             self.wifi_networks.append((ssid, wifi.get_default_password() is not None))
@@ -68,6 +66,10 @@ class WifiClient(MenuApp):
         if self.connection_timer:
             self.connection_timer.cancel()
             self.connection_timer = None
+
+        if not wifi.status():
+            # If we're not connected, stop preventing sleep
+            wifi.stop()
 
     def join_index(self, i):
         (ssid, password_required) = self.wifi_networks[i]


### PR DESCRIPTION
Also:
* Added "inactivity_time" (30s) and "boot_nosleep_time" (15s) settings
* Button presses automatically reset screen inactivity timer
* Fix TextWindow redraw if number of lines in title changes
* Apps using Wi-Fi or USB no longer call set_sleep_enabled(False), this
  is handled automatically based on whether Wi-Fi interface is up or if
  USB has enumerated.
* Remove Web REPL from main menu as it's no longer useful
* Fixed broken cancellation of on_up_down() buttons in deactivate